### PR TITLE
[FIX] Github Actions PR Develop Job 이름 변경

### DIFF
--- a/.github/workflows/pull-request-develop.yaml
+++ b/.github/workflows/pull-request-develop.yaml
@@ -6,7 +6,7 @@ on:
       - develop
 
 jobs:
-  build_modules:
+  build_modules_pr_develop:
     runs-on: ubuntu-latest
     steps:
       - name: check out repository


### PR DESCRIPTION
[FIX] Github Actions PR Develop Job 이름 변경
---
- job 이름 변경
- 추후 다른 브랜치 보호 전략과 구분 위함.