### PR TITLE
refactor: gateway server.port 환경변수로 분리 (prod 80 통일)

### DIFF
--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -22,4 +22,4 @@ spring:
     activate:
       on-profile: common
 server:
-  port: 3000
+  port: ${SERVER_PORT:3000}


### PR DESCRIPTION
## Summary

- `application.yaml` `server.port` 하드코딩 제거 → `${SERVER_PORT:3000}` 환경변수로 분리
- 로컬 환경 기본값 3000 유지, prod 환경에서는 docker-compose `SERVER_PORT: 80`으로 오버라이드

## 변경 배경

nginx proxy가 도메인 기반으로 라우팅하므로 서비스들이 호스트 포트를 노출할 필요가 없음.
내부 서비스 간 통신은 Docker 컨테이너명으로 처리하며, 포트를 80으로 통일하여 관리 단순화.
iac-terraform에서 `SERVER_PORT: 80` 환경변수를 주입하도록 함께 변경됨.

## Test plan

- [ ] 로컬 환경에서 기본 포트(3000) 정상 기동 확인
- [ ] prod 배포 후 gateway 컨테이너 포트 80 정상 기동 확인
- [ ] nginx → gateway 라우팅 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)