### PR TITLE
ci: 빌드 job을 arm64 러너로 전환, QEMU 제거

### DIFF
--- a/.github/workflows/manual-redeploy.yaml
+++ b/.github/workflows/manual-redeploy.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   manual_redeploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         service: [ gateway, payment, auth, user ]
@@ -46,9 +46,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -30,7 +30,7 @@ jobs:
   pull_request_master:
     needs: detect_changes
     if: needs.detect_changes.outputs.services != '[]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         service: ${{ fromJSON(needs.detect_changes.outputs.services) }}
@@ -52,9 +52,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -30,7 +30,7 @@ jobs:
   push_master:
     needs: detect_changes
     if: needs.detect_changes.outputs.services != '[]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         service: ${{ fromJSON(needs.detect_changes.outputs.services) }}
@@ -71,9 +71,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
- ubuntu-24.04-arm 네이티브 빌드로 QEMU 에뮬레이션 크래시 회피
- detect_changes/deploy/check_result는 ubuntu-latest 유지